### PR TITLE
✨  Add: s3 session cache config

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -27,6 +27,6 @@ jobs:
     - name: Start services for unittest
       run: docker-compose up -d
     - run: poetry install
-    - run: poetry run pytest -vv --cov=./ --cov-report=xml
+    - run: poetry run pytest -vv --cov=src --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ So if you want to use some specific remote filesystem, you need to install extra
 See [known implementations](https://github.com/fsspec/filesystem_spec/blob/a8cfd9c52a20c930c67ff296b60dbcda89d64db9/fsspec/registry.py#L87)
 to check out supported protocols.
 
+# Special Environment Variables
+| name | description |
+|-|-|
+| PATHLIBFS_S3_SESSION_CACHE | If defined, store S3 session cache locally like [boto3-session-cache](https://github.com/mixja/boto3-session-cache) |
+
 # APIs
 
 `Path` class has many methods, and it's almost same as [pathlib](https://docs.python.org/3.10/library/pathlib.html) and [fsspec.AbstractFileSystem](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem)

--- a/src/pathlibfs/__init__.py
+++ b/src/pathlibfs/__init__.py
@@ -1,4 +1,16 @@
+import os
+import warnings
+
 from .exception import PathlibfsException
 from .path import Path
+
+if "PATHLIBFS_S3_SESSION_CACHE" in os.environ:
+    try:
+        from . import s3_support
+
+        s3_support.register_session_cache()
+    except ImportError as e:  # pragma: no cover
+        warnings.warn(f"PATHLIBFS_S3_SESSION_CACHE found, but failed: {e}")
+
 
 __all__ = ["Path", "PathlibfsException"]

--- a/src/pathlibfs/s3_support.py
+++ b/src/pathlibfs/s3_support.py
@@ -1,0 +1,59 @@
+"""Support code for s3 filesystem"""
+
+import copy
+import multiprocessing
+import threading
+
+import aiobotocore.session
+import botocore.credentials
+
+
+class CredentialCache(botocore.credentials.JSONFileCache):
+    """Json file cache for multiprocessing, and in-memory cache for threads."""
+
+    _cache_storage = {}
+
+    def __init__(self, *args, **kwargs):
+        """Wrapper init"""
+        self._plock = multiprocessing.Lock()
+        self._tlock = threading.Lock()
+        CredentialCache._cache_storage = {}
+        super().__init__(*args, **kwargs)
+
+    def __contains__(self, cache_key):
+        with self._tlock:
+            if cache_key in CredentialCache._cache_storage:
+                return True
+        with self._plock:
+            return super().__contains__(cache_key)
+
+    def __getitem__(self, cache_key):
+        with self._tlock:
+            if cache_key in CredentialCache._cache_storage:
+                return copy.deepcopy(CredentialCache._cache_storage[cache_key])
+        with self._plock:
+            return super().__getitem__(cache_key)
+
+    def __delitem__(self, cache_key):
+        with self._tlock:
+            if cache_key in CredentialCache._cache_storage:
+                del CredentialCache._cache_storage[cache_key]
+        with self._plock:
+            return super().__delitem__(cache_key)
+
+    def __setitem__(self, cache_key, value):
+        with self._tlock:
+            CredentialCache._cache_storage[cache_key] = value
+        with self._plock:
+            super().__setitem__(cache_key, value)
+
+
+def register_session_cache():
+    orig_resolver = aiobotocore.session.create_credential_resolver
+
+    def _patch(*args, **kwargs):
+        """Monkey patching to aiobotocore.session.credential_resolver"""
+        kwargs["cache"] = CredentialCache()
+        return orig_resolver(*args, **kwargs)
+
+    aiobotocore.session.create_credential_resolver = _patch

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -635,3 +635,4 @@ def test_session_cache(tmp_path: pathlib.Path):
     del cache["A"]
     assert not tmp_path.joinpath("A.json").exists(), list(tmp_path.iterdir())
     assert "A" not in cache
+    assert "B" in cache


### PR DESCRIPTION
botocore could cache temporal credentials such as assume-role session token into local path.

One can enable this feature by setting `PATHLIBFS_S3_SESSION_CACHE` env var.